### PR TITLE
feat: add type and mutation config

### DIFF
--- a/src/GraphQL/DefaultSchema.php
+++ b/src/GraphQL/DefaultSchema.php
@@ -44,11 +44,17 @@ class DefaultSchema implements ConfigConvertible
     public function getConfig()
     {
         return [
+            'types' => $this->getTypes(),
             'query' => $this->getQueries(),
-            'mutation' => [],
+            'mutation' => $this->getMutations(),
             'middleware' => $this->getMiddleware(),
             'method' => ['GET', 'POST'],
         ];
+    }
+
+    private function getTypes()
+    {
+        return config('statamic.graphql.types', []);
     }
 
     private function getQueries()
@@ -72,6 +78,11 @@ class DefaultSchema implements ConfigConvertible
             ->merge(config('statamic.graphql.queries', []))
             ->merge(GraphQL::getExtraQueries())
             ->all();
+    }
+
+    private function getMutations()
+    {
+        return config('statamic.graphql.mutations', []);
     }
 
     private function getMiddleware()


### PR DESCRIPTION
Allows to add mutations and types for Graphql within the Graphql config. 