### PR TITLE
fix: refresh datepicker on site change

### DIFF
--- a/resources/js/components/fieldtypes/date/SinglePopover.vue
+++ b/resources/js/components/fieldtypes/date/SinglePopover.vue
@@ -88,6 +88,10 @@ export default {
             this.$nextTick(() => this.updateInputValue());
         },
 
+        'bindings': function () {
+            this.$nextTick(() => this.updateInputValue());
+        },
+
     },
 
     methods: {


### PR DESCRIPTION
Translatable date fields are not properly updated when using the site selection in the sidebar. The datepicker keeps showing the value from your "previous" site.

Watching `bindings` directly instead of just `bindings.value` seems to solve the issue... Quickfix since we need to get this out asap